### PR TITLE
Add basic palettes.

### DIFF
--- a/examples/randomWalk.js
+++ b/examples/randomWalk.js
@@ -1,13 +1,14 @@
 // To run: `node examples/randomWalk.js` from the root directory
 var fs = require('fs')
 var Canvas = require('canvas')
-var procgen = require('..')
 var canvas = new Canvas(1000, 1000)
-var pg = procgen(canvas)
+var pg = require('..')(canvas)
 pg.fillBackground("#FFF")
-var params = {nPaths: 10, nSteps: 5000, stepSize: 1/200, renderer: pg.renderers.circle}
+const colors = ["#005C09","#00680A","#007B0C","#018E0E","#01A611","#005C09","#00680A","#007B0C"]
+pg.setPalette(new pg.Palette({colorList: colors}))
+var params = {nPaths: 10, nSteps: 10000, stepSize: 1/100, renderer: pg.renderers.circle}
 for (var i = 0; i < params.nPaths; i++) {
-    var L = new pg.PointList({list: pg.geometry.scale(pg.random.walk2d(params.nSteps), params.stepSize)})
-    L.list.forEach(p => pg.renderPoint(p, params.renderer, {radius: 1, color: "#000"}))
+    var L = new pg.PointList({list: pg.random.walk2d(params.nSteps, {stepScale: params.stepSize})})
+    L.list.forEach(p => pg.renderPoint(p, params.renderer, {radius: 3}))
 }
 pg.save('output/randomWalk', fs)

--- a/source/Palette/index.js
+++ b/source/Palette/index.js
@@ -1,14 +1,27 @@
+import {choice, sample} from '../random';
 
-// TODO: Actually make color palettes ^.^
 export default class Palette {
-    constructor({list, probs, }) {
-        // color list with probabilities (default discrete uniform)
-        // color function [0, 1] -> C
-        // 
+    constructor({colorList, probs, color}) {
+        if (color) {
+            this.colorList = [color]
+            this.probs = [1]
+        } else if (colorList) {
+            this.colorList = colorList
+            this.probs = probs || Array(colorList.length).fill(1/colorList.length)
+        } else {
+            throw {
+                message: "Insufficient arguments to construct a palette",
+                args: arguments
+            }
+        }
     }
 
     next() {
-        return null
+        if (this.probs) {
+            return this.colorList[sample(this.probs)]
+        } else {
+            return choice(this.colorList)
+        }
     }
 
     get(x) { // maps [0, 1] to the color space

--- a/source/PointList/index.js
+++ b/source/PointList/index.js
@@ -10,7 +10,10 @@ export default class PointList {
                 this.list.push(policy(i, this.list));
             }
         } else {
-            throw "Invalid point list constructor arguments"
+            throw {
+                message: "Invalid point list constructor arguments", 
+                args: arguments
+            }
         }
     }
 
@@ -20,6 +23,18 @@ export default class PointList {
             if (policy(e, i, this)) {
                 newList.push(e)
             }
+        })
+        this.list = newList
+    }
+
+    update(updateFn) {
+        this.list = updateFn(this.list)
+    }
+
+    mapUpdate(updatePoint) {
+        var newList = []
+        this.list.forEach((e, i) => {
+            newList.push(updatePoint(e, i, this.list))
         })
         this.list = newList
     }

--- a/source/index.js
+++ b/source/index.js
@@ -1,34 +1,43 @@
 import * as geometry from './geometry';
 import * as random from './random';
 import * as renderers from './renderers';
+import Palette from './Palette';
 import PointList from './PointList';
 import * as utils from './utils';
 
 module.exports = function(canvas, bgColor = "#FFF") {
-  var ctx =  canvas.getContext('2d')
+  var ctx =  canvas.getContext("2d")
   return {
     save: (name, fs) => {
       // This only makes sense while using node canvas
-      canvas.createPNGStream().pipe(fs.createWriteStream(name + '.png'))
+      canvas.createPNGStream().pipe(fs.createWriteStream(name + ".png"))
     },
-    renderPoint: (point, render, data) => {
+    defaultPalette: new Palette({color: "#000"}),
+    setPalette: function(p) {
+      this.defaultPalette = p
+    },
+    renderPoint: function(point, render, data) {
       data.point = utils.canonicalizePoint(point, canvas)
+      data.color = data.color || this.defaultPalette.next()
       render(ctx, data)
     },
-    fillBackground: (color) => {
+    fillBackground: function(color) {
       ctx.fillStyle = color;
       ctx.fillRect(0, 0, canvas.width, canvas.height);
     },
     bgColor: bgColor,
     canvas: canvas,
-    clear: () => {
+    clear: function() {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       this.fillBackground(this.bgColor);
     },
     ctx: ctx,
+
+    // Library exports
     geometry: geometry,
     random: random,
     renderers: renderers,
-    PointList: PointList
+    PointList: PointList,
+    Palette: Palette,
   };
 }

--- a/source/math/index.js
+++ b/source/math/index.js
@@ -20,16 +20,3 @@ export function cumulativeSum(values) {
     })
     return r
 }
-
-/**
- * Samples from a discrete probability distribution
- * @param {[number]} pList 
- */
-export function sample(pList) {
-    const cumulativeP = cumulativeSum(pList)
-    if (cumulativeP[cumulativeP.length - 1] != 1) {
-        throw "Probability distribution to sample from doesn't sum to 1."
-    }
-    const draw = Math.random()
-    return cumulativeP.indexOf(cumulativeP.find(x => x > draw))
-}

--- a/source/random/index.js
+++ b/source/random/index.js
@@ -5,6 +5,27 @@ export function rand(low, high) {
     return Math.random() * (high - low) + low
 }
 
+/**
+ * Samples from a discrete probability distribution
+ * Note that the distribution need not sum to 1.
+ * @param {[number]} pList 
+ */
+export function sample(pList) {
+    const cumulativeP = cumulativeSum(pList)
+    const normalizer = cumulativeP[cumulativeP.length - 1]
+    const distribution = cumulativeP.map(x => x/normalizer)
+    const draw = Math.random()
+    return distribution.indexOf(distribution.find(x => x > draw))
+}
+
+/**
+ * Samples from a uniform discrete probability distribution
+ * @param {Array} lst
+ */
+export function choice(lst) {
+    return lst[Math.floor(Math.random() * lst.length)]
+}
+
 export function uniform(shape, low = -1, high = 1) {
     if (shape.length === 0) {
         return rand(low, high)
@@ -29,4 +50,3 @@ export function walk1d(n, {step = 1, start = 0, stepScale = 1}) {
 export function walk2d(n, {steps = [[-1, 0], [0, -1], [1, 0], [0, 1]], start = [0, 0], stepScale = 1}) {
     return cumulativeSum([start].concat(uniformDiscrete([n], scale(steps, stepScale))))
 }
-


### PR DESCRIPTION
Most notably the decision to call next from the palette if there's no color data when calling a render. This color may not necessarily be used by some renders, or could be set (in which case it isn't overwritten). Should make for easily swapping out color schemes without disrupting data creation.