### PR TITLE
Add support for animated gif output.

### DIFF
--- a/examples/growth.js
+++ b/examples/growth.js
@@ -1,12 +1,15 @@
 var fs = require('fs')
 var Canvas = require('canvas')
 var canvas = new Canvas(800, 800)
+var GIFEncoder = require('gifencoder')
 var pg = require('..')(canvas)
 pg.fillBackground("#FFF")
 
+pg.animate(GIFEncoder)
+
 var params = {nP: 36, nSteps: 400,
     renderer: pg.renderers.circle, nSpawn: 2, neighborDistance: .01, 
-    forceRatio: 1000, pointRadius: .5, stepSize: .002, spawnCap: 2}
+    forceRatio: 1000, pointRadius: .5, stepSize: .002, spawnCap: 2, stepsPerFrame: 5}
 var pts = pg.geometry.circlePoints(params.nP, .15).map(pg.Point.fromList);
 
 function neighborForce(p, q) {
@@ -50,5 +53,8 @@ var L = new pg.PointList({list: pts})
 for (var i = 0; i < params.nSteps; i++) {
     L.points.forEach(p => pg.renderPoint(p, params.renderer, {radius: params.pointRadius}))
     L.update(grow)
+    if (i % params.stepsPerFrame === 0) {
+        pg.frame()
+    }
 }
 pg.save('output/grow', fs)

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   "devDependencies": {
     "babel-cli": "^6.24.0",
     "canvas": "^1.6.5"
+  },
+  "dependencies": {
+    "gifencoder": "^1.0.6"
   }
 }

--- a/source/index.js
+++ b/source/index.js
@@ -7,10 +7,17 @@ import PointList from './PointList';
 
 module.exports = function(canvas, bgColor = "#FFF") {
   var ctx =  canvas.getContext("2d")
+  var encoder;
   return {
     save: (name, fs) => {
-      // This only makes sense while using node canvas
-      canvas.createPNGStream().pipe(fs.createWriteStream(name + ".png"))
+      if (encoder) {
+        encoder.createReadStream().pipe(fs.createWriteStream(name + '.gif'))
+        encoder.finish()
+        encoder = undefined
+      } else {
+        // This only makes sense while using node canvas
+        canvas.createPNGStream().pipe(fs.createWriteStream(name + ".png"))
+      }
     },
     defaultPalette: new Palette({color: "#000"}),
     setPalette: function(p) {
@@ -32,6 +39,16 @@ module.exports = function(canvas, bgColor = "#FFF") {
       this.fillBackground(this.bgColor);
     },
     ctx: ctx,
+    animate: function(GIFEncoder, opts) {
+      opts = opts || {}
+      encoder = new GIFEncoder(canvas.width, canvas.height)
+      encoder.setRepeat(opts.repeat === undefined ? -1 : opts.repeat);
+      encoder.setDelay(opts.delay || 16); // 60fps
+      encoder.start()
+    },
+    frame: function() {
+      encoder.addFrame(ctx)
+    },
 
     // Library exports
     geometry: geometry,


### PR DESCRIPTION
As well as static images it is now possible to create animated gif
outputs, for example showing intermediate steps. Most of the heavy
lifting is done by GIFEncoder, but there are some helper methods
to aid setup and frame capture.

The API remains synchronous so this approach will not translate to
the browser.